### PR TITLE
fix: stdlib option is not taken into account during compilation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export async function compileContract(opts: { files: string[], version?: Version
     // Resolve stdlib
     let stdlib = true;
     if (opts.stdlib === false) {
-        opts.stdlib = false;
+        stdlib = false;
     }
 
     // Resolve version


### PR DESCRIPTION
This PR fixes an issue where the `stdlib: boolean` option was not properly considered during the compilation process. The problem was caused by an invalid assignment in condition handling, which caused the parameter to be completely ignored and always included the standard library.

It's possible that this behavior was intended, but it was inconsistent with the functionality described in the repository.

With this fix, the `stdlib: boolean` option is now being properly evaluated during compilation, ensuring that the standard library is not included when not specified.

The changes in this PR should have no adverse effects on existing functionality.